### PR TITLE
Add development environment setup (AGENTS.md + ESLint config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **Next.js 15 portfolio site** (single app, no backend, no database, no env vars).
+
+### Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Install deps | `pnpm install` |
+| Dev server | `pnpm dev` (runs on port 3000, uses Turbopack) |
+| Build | `pnpm build` |
+| Lint | `pnpm lint` |
+| Typecheck | `pnpm typecheck` |
+| Format check | `pnpm format:check` |
+| Format fix | `pnpm format:write` |
+
+### Notes
+
+- The project uses **pnpm** (lockfile: `pnpm-lock.yaml`). A `package-lock.json` also exists but pnpm is the canonical package manager.
+- ESLint config is in `eslint.config.mjs` (flat config using `@eslint/eslintrc` compat layer with `next/core-web-vitals` + `next/typescript`).
+- There are pre-existing lint errors (unused imports/variables in several files) — these are in the repo baseline, not regressions.
+- No environment variables or secrets are required. All data is hardcoded.
+- `pnpm install` may warn about ignored build scripts for `sharp` and `unrs-resolver`. This is expected and does not affect functionality.
+- The contact form on `/contact` is fully commented out — no working form handler exists.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { dirname } from "path"
+import { fileURLToPath } from "url"
+import { FlatCompat } from "@eslint/eslintrc"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+})
+
+const eslintConfig = [
+    ...compat.extends("next/core-web-vitals", "next/typescript"),
+]
+
+export default eslintConfig


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cloud Agents by adding:

- **`AGENTS.md`** — Cursor Cloud specific instructions with quick reference commands and non-obvious notes about the codebase
- **`eslint.config.mjs`** — ESLint v9 flat config using `@eslint/eslintrc` compat layer with `next/core-web-vitals` + `next/typescript`. This enables `pnpm lint` to run non-interactively (previously it prompted for setup since no config file existed).

## Verification

All core development commands work:

- ✅ `pnpm install` — installs 523 packages
- ✅ `pnpm typecheck` — passes cleanly
- ✅ `pnpm build` — all 8 static pages generated successfully
- ✅ `pnpm lint` — runs successfully (pre-existing lint warnings in repo baseline)
- ✅ `pnpm dev` — dev server starts on port 3000 with Turbopack

## Demo

[portfolio-site-navigation-demo.mp4](https://cursor.com/agents/bc-5c09c6d2-44f2-44d5-8467-4f077f028bab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-site-navigation-demo.mp4)

Site navigation working — homepage, hackathons, blog, and resume pages all load correctly.

[Homepage](https://cursor.com/agents/bc-5c09c6d2-44f2-44d5-8467-4f077f028bab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Hackathons page](https://cursor.com/agents/bc-5c09c6d2-44f2-44d5-8467-4f077f028bab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhackathons_page.webp)
[Blog page](https://cursor.com/agents/bc-5c09c6d2-44f2-44d5-8467-4f077f028bab/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c09c6d2-44f2-44d5-8467-4f077f028bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c09c6d2-44f2-44d5-8467-4f077f028bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

